### PR TITLE
Added an option to allow partial chain to be accepted by the server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "warp-openssl"
-version = "0.3.4"
+version = "0.4.0"
 edition = "2021"
 description = "OpenSSL bindings for Warp TLS server"
 license = "MIT"
@@ -23,7 +23,7 @@ tokio = { version = "1" }
 tracing = "0.1"
 futures-util = "0.3"
 warp = "0.3"
-hyper = "0.14"
+hyper = { version = "0.14", features = ["stream", "server", "http1", "http2", "tcp", "client"] }
 
 [dev-dependencies]
 reqwest = {version = "0.11", features = ["native-tls"]}

--- a/src/server.rs
+++ b/src/server.rs
@@ -102,6 +102,16 @@ where
         self.with_tls(|tls| tls.client_auth_required(trust_anchor.as_ref(), certificate_verifier))
     }
 
+    /// Allow verification to succeed if an incomplete chain can be built. That is, a chain ending in a certificate that 
+    /// normally would not be trusted (because it has no matching positive trust attributes and is not self-signed) but is 
+    /// an element of the trust store. This certificate may be self-issued or belong to an intermediate CA.
+    ///
+    pub fn enable_partial_chain_verification(
+        self,
+    ) -> Self {
+        self.with_tls(|tls| tls.enable_partial_chain_verification())
+    }
+
     fn with_tls<Func>(self, func: Func) -> Self
     where
         Func: FnOnce(TlsConfigBuilder) -> TlsConfigBuilder,


### PR DESCRIPTION
By default openssl validates the full chain to a known root. In order to honor certificate pinning we want to validate until one of our intermediates is found in the chain. 