### PR TITLE
add lookup functions

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,5 @@
 use std::{
-    env,
-    fmt,
+    env, fmt,
     fs::File,
     io::{self, Cursor, Read, Write},
     sync::{Arc, Mutex},
@@ -10,8 +9,9 @@ use openssl::{
     pkey::PKey,
     ssl::{SslAcceptor, SslMethod, SslVerifyMode},
     x509::{
-        store::{X509Store, X509StoreBuilder},
-        X509, verify::X509VerifyFlags,
+        store::{HashDir, X509Lookup, X509LookupRef, X509Store, X509StoreBuilder},
+        verify::X509VerifyFlags,
+        X509,
     },
 };
 
@@ -53,12 +53,23 @@ pub(crate) enum TlsClientAuth {
     Required((Vec<u8>, Arc<dyn CertificateVerifier>)),
 }
 
+pub type LookupFileFn = Box<dyn FnOnce(&mut X509LookupRef<openssl::x509::store::File>)>;
+pub type LookupHashDirFn = Box<dyn FnOnce(&mut X509LookupRef<HashDir>)>;
+
+pub enum Lookup {
+    File(LookupFileFn),
+    HashDir(LookupHashDirFn),
+}
+
+pub type AddLookups = Vec<Lookup>;
+
 /// Builder to set the configuration for the Tls server.
 pub(crate) struct TlsConfigBuilder {
     cert: Box<dyn Read + Send + Sync>,
     key: Box<dyn Read + Send + Sync>,
     client_auth: TlsClientAuth,
     partial_chain_verification: bool,
+    add_lookups: AddLookups,
 }
 
 impl fmt::Debug for TlsConfigBuilder {
@@ -76,6 +87,7 @@ impl TlsConfigBuilder {
             cert: Box::new(io::empty()),
             client_auth: TlsClientAuth::Off,
             partial_chain_verification: true,
+            add_lookups: vec![],
         }
     }
 
@@ -111,6 +123,16 @@ impl TlsConfigBuilder {
         mut self,
     ) -> Self {
         self.partial_chain_verification = false;
+        self
+    }
+
+    pub(crate) fn add_file_lookup(mut self, lookup: LookupFileFn) -> Self {
+        self.add_lookups.push(Lookup::File(lookup));
+        self
+    }
+
+    pub(crate) fn add_hash_dir_lookup(mut self, lookup: LookupHashDirFn) -> Self {
+        self.add_lookups.push(Lookup::HashDir(lookup));
         self
     }
 }
@@ -161,6 +183,7 @@ impl TlsConfigBuilder {
         fn read_trust_anchor(
             mut trust_anchor: &[u8],
             partial_chain_verification: bool,
+            add_lookups: AddLookups,
         ) -> std::result::Result<X509Store, TlsConfigError> {
             let mut cert_vec = Vec::new();
             trust_anchor
@@ -174,8 +197,39 @@ impl TlsConfigBuilder {
                 store.add_cert(cert).map_err(TlsConfigError::OpensslError)?;
             }
 
+            let set_csr_check_flag = !add_lookups.is_empty();
+            for lookup in add_lookups.into_iter() {
+                match lookup {
+                    Lookup::File(lookup_file_fn) => {
+                        let lookup = store
+                            .add_lookup(X509Lookup::file())
+                            .map_err(TlsConfigError::OpensslError)?;
+                        lookup_file_fn(lookup);
+                    }
+                    Lookup::HashDir(lookup_hash_dir_fn) => {
+                        let lookup = store
+                            .add_lookup(X509Lookup::hash_dir())
+                            .map_err(TlsConfigError::OpensslError)?;
+                        lookup_hash_dir_fn(lookup);
+                    }
+                };
+            }
+
+            let mut flags = X509VerifyFlags::empty();
+
             if partial_chain_verification {
-                store.set_flags(X509VerifyFlags::PARTIAL_CHAIN).map_err(TlsConfigError::OpensslError)?; 
+                flags.insert(X509VerifyFlags::PARTIAL_CHAIN);
+            }
+
+            if set_csr_check_flag {
+                flags.insert(X509VerifyFlags::CRL_CHECK);
+                flags.insert(X509VerifyFlags::CRL_CHECK_ALL);
+            }
+
+            if flags != X509VerifyFlags::empty() {
+                store
+                    .set_flags(flags)
+                    .map_err(TlsConfigError::OpensslError)?;
             }
 
             Ok(store.build())
@@ -187,7 +241,11 @@ impl TlsConfigBuilder {
                 None
             }
             TlsClientAuth::Optional((trust_anchor, certificate_valiator)) => {
-                let store = read_trust_anchor(&trust_anchor, self.partial_chain_verification)?;
+                let store = read_trust_anchor(
+                    &trust_anchor,
+                    self.partial_chain_verification,
+                    self.add_lookups,
+                )?;
                 acceptor.set_verify(SslVerifyMode::PEER);
                 acceptor
                     .set_verify_cert_store(store)
@@ -195,7 +253,11 @@ impl TlsConfigBuilder {
                 Some(certificate_valiator)
             }
             TlsClientAuth::Required((trust_anchor, certificate_validator)) => {
-                let store = read_trust_anchor(&trust_anchor, self.partial_chain_verification)?;
+                let store = read_trust_anchor(
+                    &trust_anchor,
+                    self.partial_chain_verification,
+                    self.add_lookups,
+                )?;
                 acceptor.set_verify(SslVerifyMode::PEER | SslVerifyMode::FAIL_IF_NO_PEER_CERT);
                 acceptor
                     .set_verify_cert_store(store)

--- a/src/server.rs
+++ b/src/server.rs
@@ -50,9 +50,8 @@ pub fn serve<F>(filter: F) -> OpensslServer<F> {
     }
 }
 
-
 /// Create an openssl based TLS warp server with the provided filter.
-/// 
+///
 #[derive(Debug)]
 pub struct OpensslServer<F> {
     filter: F,
@@ -78,13 +77,15 @@ where
         self.with_tls(|tls| tls.cert(cert.as_ref()))
     }
 
-    /// Add file loop callback
+    /// Add file loop callback that loads all the certificates or CRLs present in a file into memory at the time the file is added as a lookup source.
+    /// See [`openssl::x509::X509Lookup::file`] for more details.
     ///
     pub fn add_file_lookup(self, lookup: LookupFileFn) -> Self {
         self.with_tls(|tls| tls.add_file_lookup(lookup))
     }
 
-    /// Add hash dir lookup callback
+    /// Add hash dir lookup callback that loads certificates and CRLs on demand and caches them in memory once they are loaded.
+    /// See [`openssl::x509::X509Lookup::hash_dir`] for more details.
     ///
     pub fn add_hash_dir_lookup(self, lookup: LookupHashDirFn) -> Self {
         self.with_tls(|tls| tls.add_hash_dir_lookup(lookup))
@@ -114,14 +115,12 @@ where
         self.with_tls(|tls| tls.client_auth_required(trust_anchor.as_ref(), certificate_verifier))
     }
 
-    /// **Not recommended** Disables partial certificate chain verification. 
-    /// 
+    /// **Not recommended** Disables partial certificate chain verification.
+    ///
     /// For certificate pinning to work properly its enough to validate that
     /// the certificate chains to an anchor in the trust store. This is the default behavior.
     ///
-    pub fn disable_partial_chain_verification(
-        self,
-    ) -> Self {
+    pub fn disable_partial_chain_verification(self) -> Self {
         self.with_tls(|tls| tls.disable_partial_chain_verification())
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::acceptor::TlsAcceptor;
 use crate::certificate::CertificateVerifier;
-use crate::config::TlsConfigBuilder;
+use crate::config::{LookupFileFn, LookupHashDirFn, TlsConfigBuilder};
 use crate::Result;
 
 use futures_util::{Future, FutureExt, TryFuture};
@@ -76,6 +76,18 @@ where
     ///
     pub fn cert(self, cert: impl AsRef<[u8]>) -> Self {
         self.with_tls(|tls| tls.cert(cert.as_ref()))
+    }
+
+    /// Add file loop callback
+    ///
+    pub fn add_file_lookup(self, lookup: LookupFileFn) -> Self {
+        self.with_tls(|tls| tls.add_file_lookup(lookup))
+    }
+
+    /// Add hash dir lookup callback
+    ///
+    pub fn add_hash_dir_lookup(self, lookup: LookupHashDirFn) -> Self {
+        self.with_tls(|tls| tls.add_hash_dir_lookup(lookup))
     }
 
     /// Specify the in-memory contents of the trust anchor for optional client authentication.


### PR DESCRIPTION
Add lookup callbacks to read the certificate revocation list. If a lookup function is added, the client certificate will get checked