### PR TITLE
Rename sn to cn and add ou

### DIFF
--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -6,18 +6,24 @@ use crate::Result;
 /// Certificate information for a TLS connection.
 #[derive(Debug)]
 pub struct Certificate {
-    subject_name: String,
+    common_name: String,
 }
 
 impl Certificate {
     /// Creates a new certificate.
-    pub(crate) fn new(subject_name: String) -> Certificate {
-        Certificate { subject_name }
+    pub(crate) fn new(common_name: String) -> Certificate {
+        Certificate { common_name }
     }
 
-    /// Returns the subject name of the certificate.
+    /// Returns the common name of the certificate.
+    #[deprecated(note = "please use `common_name` instead")]
     pub fn subject_name(&self) -> &str {
-        &self.subject_name
+        &self.common_name
+    }
+
+    /// Returns the common name of the certificate.
+    pub fn common_name(&self) -> &str {
+        &self.common_name
     }
 }
 

--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -6,13 +6,14 @@ use crate::Result;
 /// Certificate information for a TLS connection.
 #[derive(Debug)]
 pub struct Certificate {
+    //TODO: Change to Option when `subject_name` is removed.
     common_name: String,
-    organizational_unit: String,
+    organizational_unit: Option<String>,
 }
 
 impl Certificate {
     /// Creates a new certificate.
-    pub(crate) fn new(common_name: String, organizational_unit: String) -> Certificate {
+    pub(crate) fn new(common_name: String, organizational_unit: Option<String>) -> Certificate {
         Certificate {
             common_name,
             organizational_unit,
@@ -26,13 +27,13 @@ impl Certificate {
     }
 
     /// Returns the common name of the certificate.
-    pub fn common_name(&self) -> &str {
-        &self.common_name
+    pub fn common_name(&self) -> Option<&str> {
+        Some(&self.common_name)
     }
 
     /// Returns the organizational unit of the certificate.
-    pub fn organizational_unit(&self) -> &str {
-        &self.organizational_unit
+    pub fn organizational_unit(&self) -> Option<&str> {
+        self.organizational_unit.as_deref()
     }
 }
 

--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -7,12 +7,16 @@ use crate::Result;
 #[derive(Debug)]
 pub struct Certificate {
     common_name: String,
+    organizational_unit: String,
 }
 
 impl Certificate {
     /// Creates a new certificate.
-    pub(crate) fn new(common_name: String) -> Certificate {
-        Certificate { common_name }
+    pub(crate) fn new(common_name: String, organizational_unit: String) -> Certificate {
+        Certificate {
+            common_name,
+            organizational_unit,
+        }
     }
 
     /// Returns the common name of the certificate.
@@ -24,6 +28,11 @@ impl Certificate {
     /// Returns the common name of the certificate.
     pub fn common_name(&self) -> &str {
         &self.common_name
+    }
+
+    /// Returns the organizational unit of the certificate.
+    pub fn organizational_unit(&self) -> &str {
+        &self.organizational_unit
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -91,12 +91,9 @@ impl TlsStream {
                                     .map(|x| x.eq("OU"))
                                     .unwrap_or_default()
                             })
-                            .ok_or_else(|| {
-                                io::Error::new(io::ErrorKind::Other, "No OU in client certificate")
-                            })?
-                            .data()
-                            .as_utf8()?
-                            .to_string();
+                            .and_then(|name_entry| {
+                                name_entry.data().as_utf8().ok().map(|s| s.to_string())
+                            });
                         let cert = Certificate::new(common_name, organizational_unit);
                         certificate_verifier
                             .verify_certificate(&cert)


### PR DESCRIPTION
 * Rename `subject_name` to to the most widely used identifier `common_name`. The old function is kept but deprecated to not break existing code
 * Add `organizational_unit`

Should we make both fields optional to let the `CertificateVerifier` the choice whether it wants to accept a certificate without `common name` or `organizational unit`? This change would be breaking as the method `subject_name` would need to be changed. I would suggest to remove it if we do this change.