### PR TITLE
Certificate in filter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,10 @@ version = "0.5.3"
 edition = "2021"
 description = "OpenSSL bindings for Warp TLS server"
 license = "MIT"
-authors = ["Sandeep Bansal <sandeep.bansal85@gmail.com>"]
+authors = [
+    "Sandeep Bansal <sandeep.bansal85@gmail.com>",
+    "René Rössler <rene@freshx.de>",
+]
 readme = "README.md"
 documentation = "https://docs.rs/warp-openssl"
 repository = "https://github.com/Azure/warp-openssl"
@@ -23,10 +26,17 @@ tokio = { version = "1" }
 tracing = "0.1"
 futures-util = "0.3"
 warp = "0.3"
-hyper = { version = "0.14", features = ["stream", "server", "http1", "http2", "tcp", "client"] }
+hyper = { version = "0.14", features = [
+    "stream",
+    "server",
+    "http1",
+    "http2",
+    "tcp",
+    "client",
+] }
 
 [dev-dependencies]
-reqwest = {version = "0.11", features = ["rustls-tls", "native-tls"]}
+reqwest = { version = "0.11", features = ["rustls-tls", "native-tls"] }
 rstest = "0.18.1"
 clap = { version = "4.4.18", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,10 +1,9 @@
+use clap::Parser;
 use reqwest::tls::Version;
 use reqwest::{Certificate, ClientBuilder, Identity};
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 use warp_openssl::Result;
-use clap::Parser;
-
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -22,17 +21,17 @@ struct Args {
 /// Requires openssl to be installed.
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt().with_env_filter(EnvFilter::from_default_env()).init();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
 
     let ca_cert = include_bytes!("../certs/ca.crt").to_vec();
     let crt = include_bytes!("../certs/client.crt").to_vec();
     let key = include_bytes!("../certs/client.key").to_vec();
 
     let args = Args::parse();
-    
-    let identity = Identity::from_pem(
-        &[key, crt].concat(),
-    )?;
+
+    let identity = Identity::from_pem(&[key, crt].concat())?;
 
     let trust_root = Certificate::from_pem(&ca_cert).unwrap();
     let builder = ClientBuilder::new()
@@ -54,6 +53,6 @@ async fn main() -> Result<()> {
         .await;
 
     info!("Response: {:?}", res);
-    
+
     Ok(())
 }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,24 +1,20 @@
+use std::{net::SocketAddr, sync::Arc};
 use tokio::signal::ctrl_c;
+use tokio::sync::oneshot;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
-use std::{net::SocketAddr, sync::Arc};
-use tokio::sync::oneshot;
 use warp_openssl::Result;
-use warp_openssl::{CertificateVerifier, serve};
+use warp_openssl::{serve, CertificateVerifier};
 
 struct ValidCertVerifier {}
 
 impl CertificateVerifier for ValidCertVerifier {
-    fn verify_certificate(
-        &self,
-        _: &warp_openssl::Certificate,
-    ) -> warp_openssl::Result<()> {
+    fn verify_certificate(&self, _: &warp_openssl::Certificate) -> warp_openssl::Result<()> {
         Result::Ok(())
     }
 }
 
 use clap::Parser;
-
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -36,24 +32,26 @@ struct Args {
 /// Requires openssl to be installed.
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt().with_env_filter(EnvFilter::from_default_env()).init();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
 
     let args = Args::parse();
-    
+
     let addr = SocketAddr::from(([127, 0, 0, 1], args.port));
     let ca_cert = include_bytes!("../certs/ca.crt").to_vec();
     let mut host_cert = include_bytes!("../certs/localhost.crt").to_vec();
     host_cert.extend(ca_cert.clone());
 
-    
     let intermediate_cert = include_bytes!("../certs/intermediate.crt").to_vec();
-    
+
     let (tx, rx) = oneshot::channel::<()>();
     let server = serve(warp::Filter::map(warp::any(), || "Hello, World!"))
-        .key(include_bytes!("../certs/localhost.key").to_vec())
+        .key(include_bytes!("../certs/localhost.key"))
         .cert(host_cert);
 
-    let server = server.client_auth_required(intermediate_cert.clone(), Arc::new(ValidCertVerifier {}));
+    let server =
+        server.client_auth_required(intermediate_cert.clone(), Arc::new(ValidCertVerifier {}));
 
     let (addr, server) = server.bind_with_graceful_shutdown(addr, async move {
         rx.await.ok();

--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -16,7 +16,7 @@ pub struct Certificate {
 impl TryFrom<X509> for Certificate {
     type Error = std::io::Error;
 
-    fn try_from(cert: X509) -> std::prelude::v1::Result<Self, Self::Error> {
+    fn try_from(cert: X509) -> std::io::Result<Self> {
         let mut common_names = vec![];
         let mut organizational_units = vec![];
         let mut localities = vec![];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,21 +7,21 @@
 //!
 //! warp-openssl adds an openssl compatibility layer  to [warp](https://docs.rs/warp).
 //!
-//! By default warp ships with support for rustls as the TLS layer which makes warp 
+//! By default warp ships with support for rustls as the TLS layer which makes warp
 //! unusable in some environments where only openssl is allowed.
-//! 
-//! In order to use the openssl compatibility layer just import serve from warp_openssl 
+//!
+//! In order to use the openssl compatibility layer just import serve from warp_openssl
 //! instead of warp.
-//! 
+//!
 //! So the following example:
 //! ```
 //!  use warp::serve;
-//! 
+//!
 //!  let server = serve(warp::Filter::map(warp::any(), || "Hello, World!"));
 //! ```
-//! 
+//!
 //! would convert to:
-//! 
+//!
 //! ```
 //!  use warp_openssl::serve;
 //!  
@@ -31,10 +31,25 @@
 //!     .key(key)
 //!     .cert(cert);
 //! ```
-//! 
+//!
 //! There is additional support for SSL key logging file to enable viewing network traffic in wireshark.
 //! Just set the SSLKEYLOGFILE environment variable to the path of the file you want to use
 //! and the key log gets generated to that file.
+//!
+//! The client certificate can be accessed in a filter by getting the extension:
+//!
+//!  ```
+//!  use warp_openssl::serve;
+//!  
+//!  let cert = vec![]; // certificate to use
+//!  let key = vec![]; // private key for the certificate
+//!  let server = serve(warp::Filter::map(
+//!     warp::Filter::and(warp::any(), warp::filters::ext::optional()),
+//!     |_cert: Option<warp_openssl::Certificate>| "Hello, World!"
+//!  ))
+//!  .key(key)
+//!  .cert(cert);
+//! ```
 
 #[doc(hidden)]
 pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -45,7 +60,7 @@ mod acceptor;
 mod certificate;
 mod config;
 mod server;
-pub use server::{OpensslServer, serve};
 mod stream;
 
 pub use certificate::{Certificate, CertificateVerifier};
+pub use server::{serve, OpensslServer};

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -4,15 +4,12 @@ use rstest::*;
 use std::{net::SocketAddr, sync::Arc};
 use tokio::sync::oneshot;
 use warp_openssl::Result;
-use warp_openssl::{CertificateVerifier, serve};
+use warp_openssl::{serve, CertificateVerifier};
 
 struct ValidCertVerifier {}
 
 impl CertificateVerifier for ValidCertVerifier {
-    fn verify_certificate(
-        &self,
-        _: &warp_openssl::Certificate,
-    ) -> warp_openssl::Result<()> {
+    fn verify_certificate(&self, _: &warp_openssl::Certificate) -> warp_openssl::Result<()> {
         Result::Ok(())
     }
 }
@@ -20,10 +17,7 @@ impl CertificateVerifier for ValidCertVerifier {
 struct InValidCertVerifier {}
 
 impl CertificateVerifier for InValidCertVerifier {
-    fn verify_certificate(
-        &self,
-        _: &warp_openssl::Certificate,
-    ) -> warp_openssl::Result<()> {
+    fn verify_certificate(&self, _: &warp_openssl::Certificate) -> warp_openssl::Result<()> {
         Result::Err("Invalid certificate".into())
     }
 }
@@ -91,31 +85,26 @@ async fn client_tests(
     let mut host_cert = include_bytes!("../certs/localhost.crt").to_vec();
     host_cert.extend(ca_cert.clone());
 
-    
     let intermediate_cert = include_bytes!("../certs/intermediate.crt").to_vec();
-    
+
     let (tx, rx) = oneshot::channel::<()>();
     let server = serve(warp::Filter::map(warp::any(), || "Hello, World!"))
-        .key(include_bytes!("../certs/localhost.key").to_vec())
+        .key(include_bytes!("../certs/localhost.key"))
         .cert(host_cert);
 
     let server = match auth_type {
         AuthType::Off => server,
         AuthType::Required => match verifier_type {
-            VeriferType::Valid => {
-                server.client_auth_required(intermediate_cert.clone(), Arc::new(ValidCertVerifier {}))
-            }
-            VeriferType::Invalid => {
-                server.client_auth_required(intermediate_cert.clone(), Arc::new(InValidCertVerifier {}))
-            }
+            VeriferType::Valid => server
+                .client_auth_required(intermediate_cert.clone(), Arc::new(ValidCertVerifier {})),
+            VeriferType::Invalid => server
+                .client_auth_required(intermediate_cert.clone(), Arc::new(InValidCertVerifier {})),
         },
         AuthType::Optional => match verifier_type {
-            VeriferType::Valid => {
-                server.client_auth_optional(intermediate_cert.clone(), Arc::new(ValidCertVerifier {}))
-            }
-            VeriferType::Invalid => {
-                server.client_auth_optional(intermediate_cert.clone(), Arc::new(InValidCertVerifier {}))
-            }
+            VeriferType::Valid => server
+                .client_auth_optional(intermediate_cert.clone(), Arc::new(ValidCertVerifier {})),
+            VeriferType::Invalid => server
+                .client_auth_optional(intermediate_cert.clone(), Arc::new(InValidCertVerifier {})),
         },
     };
 
@@ -129,12 +118,10 @@ async fn client_tests(
 
     let crt = include_bytes!("../certs/client.crt").to_vec();
     let key = include_bytes!("../certs/client.key").to_vec();
-    let identity = Identity::from_pem(
-        &[key, crt].concat(),
-    )?;
+    let identity = Identity::from_pem(&[key, crt].concat())?;
 
     let trust_root = Certificate::from_pem(&ca_cert).unwrap();
-    
+
     for version in [Version::TLS_1_2, Version::TLS_1_3] {
         println!("Testing with version: {:?}", version);
 
@@ -150,24 +137,22 @@ async fn client_tests(
         } else {
             builder
         };
-    
+
         let client = builder.build()?;
         let res = client
             .get(format!("https://localhost:{}", addr.port()))
             .send()
             .await;
-    
+
         println!("Response: {:?}", res);
-        
+
         if let Ok(ref res) = res {
-            assert_eq!(expect_error, false);
+            assert!(!expect_error);
             assert_eq!(res.status(), 200);
         } else {
-            assert_eq!(expect_error, true);
-            
+            assert!(expect_error);
         }
     }
-
 
     tx.send(()).unwrap();
     server.await.unwrap();


### PR DESCRIPTION
I reworked some parts to make it possible to access the client/peer certificate in a filter.

I added an example on how to use it and extended the test case to check if it is working as intended.

@msabansal  What do you think? Should this be behind a feature flag as it is work which might not be needed for every request?

I also added myself to the authors as I feel this might be a big enough pull request for that :)